### PR TITLE
Fix crimeo's bugs

### DIFF
--- a/src/main/java/com/github/maxopoly/MemeMana/command/CmdManaRefill.java
+++ b/src/main/java/com/github/maxopoly/MemeMana/command/CmdManaRefill.java
@@ -14,6 +14,7 @@ import java.util.function.IntFunction;
 import java.util.function.BiConsumer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import com.civclassic.altmanager.AltManager;
 import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 import net.md_5.bungee.api.ChatColor;
@@ -36,7 +37,8 @@ public class CmdManaRefill extends PlayerCommand {
 			return true;
 		}
 		Player player = (Player) sender;
-		ExilePearl pearl = ExilePearlPlugin.getApi().getPearlFromItemStack(player.getInventory().getItemInMainHand());
+		ItemStack pearlStack = player.getInventory().getItemInMainHand();
+		ExilePearl pearl = ExilePearlPlugin.getApi().getPearlFromItemStack(pearlStack);
 		if (pearl == null) {
 			sender.sendMessage(ChatColor.RED + "You must be holding a pearl to refill it");
 			return true;
@@ -74,6 +76,7 @@ public class CmdManaRefill extends PlayerCommand {
 		};
 		if(pouch.removeMana(manaToUse,logUsage)) {
 			pearl.setHealth(Math.min(healthBefore + repairPerUnitMana * manaToUse,maxHealth));
+			pearl.validateItemStack(pearlStack);
 			IntFunction<Integer> toPercent = h -> Math.min(100, Math.max(0, (int)Math.round(((double)h / maxHealth) * 100)));
 			sender.sendMessage(ChatColor.GREEN + "The pearl was repaired from " + ChatColor.YELLOW + toPercent.apply(healthBefore) + "%" + ChatColor.GREEN + " health to " + ChatColor.YELLOW + toPercent.apply(pearl.getHealth()) + "%" + ChatColor.GREEN + " health, consuming " + ChatColor.GOLD + manaToUse + " mana");
 		}

--- a/src/main/java/com/github/maxopoly/MemeMana/command/CmdManaTransfer.java
+++ b/src/main/java/com/github/maxopoly/MemeMana/command/CmdManaTransfer.java
@@ -37,6 +37,10 @@ public class CmdManaTransfer extends PlayerCommand {
 			sender.sendMessage(ChatColor.DARK_RED + args[0] + ChatColor.RED + " is not a valid mana owner");
 			return false;
 		}
+		if(MemeManaOwnerManager.fromPlayer(player) == transferTo){
+			sender.sendMessage(ChatColor.RED + "Can't transfer mana to yourself");
+			return false;
+		}
 		
 		MemeManaPouch fromPouch = MemeManaPouch.getPouch(MemeManaOwnerManager.fromPlayer(player));
 		int transferAmount = fromPouch.getManaContent();

--- a/src/main/java/com/github/maxopoly/MemeMana/command/CmdManaUpgrade.java
+++ b/src/main/java/com/github/maxopoly/MemeMana/command/CmdManaUpgrade.java
@@ -3,6 +3,7 @@ package com.github.maxopoly.MemeMana.command;
 import com.devotedmc.ExilePearl.ExilePearl;
 import com.devotedmc.ExilePearl.PearlType;
 import com.devotedmc.ExilePearl.ExilePearlPlugin;
+import com.devotedmc.ExilePearl.util.SpawnUtil;
 import com.github.maxopoly.MemeMana.MemeManaPlugin;
 import com.github.maxopoly.MemeMana.MemeManaDAO;
 import com.github.maxopoly.MemeMana.MemeManaOwnerManager;
@@ -64,6 +65,10 @@ public class CmdManaUpgrade extends PlayerCommand {
 			pearl.setPearlType(PearlType.PRISON);
 			pearl.setHealth(ExilePearlPlugin.getApi().getPearlConfig().getPearlHealthStartValue());
 			sender.sendMessage(ChatColor.GREEN + "The pearl was successfully upgraded");
+			if(pearl.getPlayer() != null && pearl.getPlayer().isOnline()) {
+				SpawnUtil.spawnPlayer(pearl.getPlayer(), ExilePearlPlugin.getApi().getPearlConfig().getPrisonWorld());
+				pearl.getPlayer().sendMessage(ChatColor.YELLOW + "You've been imprisoned in the end by " + player.getDisplayName() + ".");
+			}
 		}
 		return true;
 	}

--- a/src/main/java/com/github/maxopoly/MemeMana/command/CmdManaUpgrade.java
+++ b/src/main/java/com/github/maxopoly/MemeMana/command/CmdManaUpgrade.java
@@ -16,6 +16,7 @@ import java.util.function.IntFunction;
 import java.util.function.BiConsumer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import com.civclassic.altmanager.AltManager;
 import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 import net.md_5.bungee.api.ChatColor;
@@ -38,7 +39,8 @@ public class CmdManaUpgrade extends PlayerCommand {
 			return true;
 		}
 		Player player = (Player) sender;
-		ExilePearl pearl = ExilePearlPlugin.getApi().getPearlFromItemStack(player.getInventory().getItemInMainHand());
+		ItemStack pearlStack = player.getInventory().getItemInMainHand();
+		ExilePearl pearl = ExilePearlPlugin.getApi().getPearlFromItemStack(pearlStack);
 		if (pearl == null) {
 			sender.sendMessage(ChatColor.RED + "You must be holding a pearl to upgrade it");
 			return true;
@@ -64,6 +66,7 @@ public class CmdManaUpgrade extends PlayerCommand {
 		if(pouch.removeMana(pearlUpgradeCost,logUsage)) {
 			pearl.setPearlType(PearlType.PRISON);
 			pearl.setHealth(ExilePearlPlugin.getApi().getPearlConfig().getPearlHealthStartValue());
+			pearl.validateItemStack(pearlStack);
 			sender.sendMessage(ChatColor.GREEN + "The pearl was successfully upgraded");
 			if(pearl.getPlayer() != null && pearl.getPlayer().isOnline()) {
 				SpawnUtil.spawnPlayer(pearl.getPlayer(), ExilePearlPlugin.getApi().getPearlConfig().getPrisonWorld());

--- a/src/main/java/com/github/maxopoly/MemeMana/model/MemeManaPouch.java
+++ b/src/main/java/com/github/maxopoly/MemeMana/model/MemeManaPouch.java
@@ -139,10 +139,10 @@ public class MemeManaPouch {
 	// Must keep decay times correct
 	// true means successful
 	public boolean transferMana(MemeManaPouch toPouch, int amount) {
-		dao.logManaTransfer(ownerId, toPouch.ownerId, amount);
 		if(getManaContent() < amount){
 			return false;
 		}
+		dao.logManaTransfer(ownerId, toPouch.ownerId, amount);
 		TreeMap<Long,Integer> otherPouchRaw = toPouch.getRawUnits();
 		int leftToRemove = amount;
 		Long lastTimestampRemoved = null;


### PR DESCRIPTION
This fixes:

- Gaps in the UUID table
- Broken af mana transfer when full units of the same timestamp were involved
- Pearls not updating when refilled/upgraded
- Logging failed mana transfers as successful ones