### PR TITLE
Prototype pearled player streak system

### DIFF
--- a/src/main/java/com/github/maxopoly/MemeMana/MemeManaConfig.java
+++ b/src/main/java/com/github/maxopoly/MemeMana/MemeManaConfig.java
@@ -91,4 +91,18 @@ public class MemeManaConfig {
 	public int getPearlUpgradeAmount() {
 		return plugin.getConfig().getInt("pearlUpgradeAmount", 10);
 	}
+
+	/**
+	 * @return How much it damages pearls to log in on day one
+	 */
+	public int getPearlDamageCurveInitial() {
+		return plugin.getConfig().getInt("pearlDamageCurveInitial", 1);
+	}
+
+	/**
+	 * @return How much it damages pearls each day you log in after the first day
+	 */
+	public int getPearlDamageCurveIncrement() {
+		return plugin.getConfig().getInt("pearlDamageCurveIncrment", 1);
+	}
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,6 +13,8 @@ manaGainTimeout: 22h
 manaWaitTime: 30m
 maximumDailyMana: 10
 pearlRefillAmount: 
-  EXILE: 1
-  PRISON: 1
-pearlupgradeAmount: 10
+  EXILE: 168
+  PRISON: 21
+pearlupgradeAmount: 64
+pearlDamageCurveInitial: 1
+pearlDamageCurveIncrement: 1


### PR DESCRIPTION
Pearled players damage their pearl by logging in, and do more damage for more activity, same as gaining Mana for non-pearled players.

Not tested. This is only here to keep track of the fact that this exists.